### PR TITLE
feat: allow search to pass language and time budget

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -22,8 +22,14 @@ server.registerTool(
       timeBudgetMs: z.number().int().min(500).max(10000).default(Number(process.env.FAST_TIME_BUDGET_MS || 1800)).optional()
     }
   },
-  async ({ query, mode = "auto", limit = Number(process.env.MAX_RESULTS || 5) }) => {
-    const res = await runTwoTierSearch(query, mode, limit);
+  async ({
+    query,
+    mode = "auto",
+    limit = Number(process.env.MAX_RESULTS || 5),
+    language = process.env.LANG_DEFAULT || "vi",
+    timeBudgetMs = Number(process.env.FAST_TIME_BUDGET_MS || 1800),
+  }) => {
+    const res = await runTwoTierSearch(query, mode, limit, language, timeBudgetMs);
     const payload = {
       items: res.items,
       modeUsed: res.modeUsed,


### PR DESCRIPTION
## Summary
- support optional `language` and `timeBudgetMs` parameters for `runTwoTierSearch`
- forward language/time budget to DuckDuckGo and Playwright search engines
- include language and time budget diagnostics in server `search_web` responses

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a27f37428c83339bb2f94289b4977b