### PR TITLE
feat: support multi-language Accept-Language headers

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -68,7 +68,7 @@ server.registerTool(
     inputSchema: { url: z.string().url(), bullets: z.number().int().min(3).max(10).default(5).optional(), language: z.string().default("auto").optional() }
   },
   async ({ url, bullets = 5, language = "auto" }) => {
-    const doc = await fetchAndExtract(url);
+    const doc = await fetchAndExtract(url, language === "auto" ? undefined : language);
     const prompt = `Hãy tóm tắt nội dung dưới đây thành ${bullets} gạch đầu dòng.
 - Ngôn ngữ đầu ra: ${language}
 - Giữ các ý chính, con số quan trọng, loại bỏ rườm rà.


### PR DESCRIPTION
## Summary
- allow custom language in `uaHeaders()` and document header behavior
- pass language from `summarize_url` tool to extraction

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a27f56bdbc8333b0e481a1890518b0