### PR TITLE
chore: update startup log message

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -104,7 +104,7 @@ server.registerTool(
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error("mcp-universal-tools-auto ready (stdio)…");
+  console.error("mcp-web-calc ready (stdio)…");
 }
 
 main().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- replace old startup log text with new "mcp-web-calc" readiness message

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a27f73fe7c8333b341b1e0ef10c944