### PR TITLE
Harden networking: timeouts, Playwright cleanup, SSRF guard, size cap…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,10 @@
 # Tuỳ chọn (không bắt buộc) — dùng để tinh chỉnh hành vi
-USER_AGENT=mcp-universal-tools/0.1 (https://local)
-HTTP_TIMEOUT=15000
-MAX_RESULTS=5
+USER_AGENT=mcp-web-calc/0.2 (https://local)
+HTTP_TIMEOUT=15000  # ms
+MAX_RESULTS=10
 LANG_DEFAULT=vi
 # Ngân sách thời gian cho tầng tìm kiếm nhanh (ms)
 FAST_TIME_BUDGET_MS=1800
+
+# Optional: cap fetched document size (bytes)
+MAX_BYTES=20971520

--- a/src/engines.ts
+++ b/src/engines.ts
@@ -25,6 +25,23 @@ function uaHeaders(lang = process.env.LANG_DEFAULT || "vi") {
   return { "User-Agent": ua, "Accept-Language": acceptLang } as Record<string, string>;
 }
 
+function toMs(env: string | undefined, def: number) {
+  const n = Number(env);
+  return Number.isFinite(n) && n > 0 ? n : def;
+}
+
+async function fetchWithTimeout(input: RequestInfo | URL, init: RequestInit = {}, timeoutMs = 15000): Promise<Response> {
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+const HTTP_TIMEOUT = toMs(process.env.HTTP_TIMEOUT, 15000);
+
 function decodeDuckDuckGoRedirect(href: string): string {
   try {
     const u = new URL(href, "https://duckduckgo.com/");
@@ -41,7 +58,7 @@ function decodeDuckDuckGoRedirect(href: string): string {
 async function ddgHtmlSearch(q: string, limit: number, lang: string): Promise<SearchItem[]> {
   const url = new URL("https://html.duckduckgo.com/html/");
   url.searchParams.set("q", q);
-  const res = await fetch(url, { headers: uaHeaders(lang) });
+  const res = await fetchWithTimeout(url, { headers: uaHeaders(lang) }, HTTP_TIMEOUT);
   if (!res.ok) throw new Error(`DuckDuckGo HTML ${res.status}`);
   const html = await res.text();
   const dom = new JSDOM(html, { url: "https://duckduckgo.com/?q=" + encodeURIComponent(q) });
@@ -51,8 +68,9 @@ async function ddgHtmlSearch(q: string, limit: number, lang: string): Promise<Se
   const items: SearchItem[] = [];
   for (let i = 0; i < anchors.length && items.length < limit; i++) {
     const a = anchors[i] as HTMLAnchorElement;
+    const title = (a.textContent || "").trim();
     const href = decodeDuckDuckGoRedirect(a.getAttribute("href") || "");
-    const title = a.textContent?.trim() || href;
+    if (!title || !href) continue;
     const sn = (snippets[i]?.textContent || "").trim() || undefined;
     try {
       const u = new URL(href);
@@ -67,58 +85,71 @@ async function bingPlaywrightSearch(q: string, limit: number, lang: string): Pro
   const browser = await chromium.launch({ headless: true });
   const context = await browser.newContext({
     locale: lang === "vi" ? "vi-VN" : "en-US",
-    userAgent: (process.env.USER_AGENT || "mcp-web-calc/0.2") + " Playwright"
+    userAgent: (process.env.USER_AGENT || "mcp-web-calc/0.2") + " Playwright",
   });
-  const page = await context.newPage();
-  const url = new URL("https://www.bing.com/search");
-  url.searchParams.set("q", q);
-  if (lang) url.searchParams.set("setlang", lang === "vi" ? "vi" : "en");
-  await page.goto(url.toString(), { waitUntil: "domcontentloaded", timeout: 30000 });
-  // Bing structure: li.b_algo h2 a ; snippet in div.b_caption p or div.b_snippet
-  const results: SearchItem[] = [];
-  const cards = await page.$$("li.b_algo");
-  for (const card of cards) {
-    const a = await card.$("h2 a");
-    if (!a) continue;
-    const title = (await a.textContent())?.trim() || "";
-    const href = await a.getAttribute("href");
-    if (!href || !title) continue;
-    let snippet = (await card.$eval("div.b_caption p", el => el.textContent || "").catch(() => "")) as string;
-    if (!snippet) {
-      snippet = await card.$eval("div.b_snippet", el => el.textContent || "").catch(() => "") as string;
+  try {
+    const page = await context.newPage();
+    const url = new URL("https://www.bing.com/search");
+    url.searchParams.set("q", q);
+    if (lang) url.searchParams.set("setlang", lang === "vi" ? "vi" : "en");
+    await page.goto(url.toString(), { waitUntil: "domcontentloaded", timeout: 30000 });
+    const results: SearchItem[] = [];
+    const cards = await page.$$("li.b_algo");
+    for (const card of cards) {
+      const a = await card.$("h2 a");
+      if (!a) continue;
+      const title = (await a.textContent())?.trim() || "";
+      const href = await a.getAttribute("href");
+      if (!href || !title) continue;
+      let snippet = (await card.$eval("div.b_caption p", el => (el as HTMLElement).textContent || "").catch(() => "")) as string;
+      if (!snippet) {
+        snippet = await card.$eval("div.b_snippet", el => (el as HTMLElement).textContent || "").catch(() => "") as string;
+      }
+      try {
+        const u = new URL(href);
+        results.push({ title, url: u.toString(), snippet: snippet?.trim() || undefined, source: "bing_pw" });
+      } catch {}
+      if (results.length >= limit) break;
     }
-    try {
-      const u = new URL(href);
-      results.push({ title, url: u.toString(), snippet: snippet?.trim() || undefined, source: "bing_pw" });
-    } catch {}
-    if (results.length >= limit) break;
+    return results;
+  } finally {
+    await context.close().catch(() => {});
+    await browser.close().catch(() => {});
   }
-  await browser.close();
-  return results;
 }
 
 export async function runTwoTierSearch(opts: { q: string; limit?: number; lang?: string; mode?: SearchMode; timeoutMs?: number }): Promise<SearchResponse> {
-  const { q, limit = 10, lang = "vi", mode = "auto" } = opts;
+  const { q } = opts;
+  const limit = Math.max(1, Math.min(Number(opts.limit ?? Number(process.env.MAX_RESULTS) || 10), 50));
+  const lang = opts.lang ?? (process.env.LANG_DEFAULT || "vi");
+  const mode = opts.mode ?? "auto";
+
   const enginesUsed: EngineName[] = [];
   const diagnostics: Record<string, unknown> = {};
+
   if (mode === "fast") {
     const fast = await ddgHtmlSearch(q, limit, lang);
     enginesUsed.push("ddg_html");
-    return { items: fast, modeUsed: "fast", enginesUsed, escalated: false, diagnostics: { ...diagnostics, fastCount: fast.length } };
+    diagnostics["fastCount"] = fast.length;
+    return { items: fast, modeUsed: "fast", enginesUsed, escalated: false, diagnostics };
   }
+
   if (mode === "deep") {
     const deep = await bingPlaywrightSearch(q, limit, lang);
     enginesUsed.push("bing_pw");
-    return { items: deep, modeUsed: "deep", enginesUsed, escalated: false, diagnostics: { ...diagnostics, deepCount: deep.length } };
+    diagnostics["deepCount"] = deep.length;
+    return { items: deep, modeUsed: "deep", enginesUsed, escalated: false, diagnostics };
   }
-  // auto: run fast, escalate if too few
+
+  // auto: run fast first, then escalate to deep if too few
   const fast = await ddgHtmlSearch(q, limit, lang);
   enginesUsed.push("ddg_html");
   diagnostics["fastCount"] = fast.length;
   if (fast.length < Math.min(3, limit)) {
     const deep = await bingPlaywrightSearch(q, limit, lang);
     enginesUsed.push("bing_pw");
-    return { items: [...fast, ...deep].slice(0, limit), modeUsed: "auto", enginesUsed, escalated: true, diagnostics: { ...diagnostics, deepCount: deep.length } };
+    diagnostics["deepCount"] = deep.length;
+    return { items: [...fast, ...deep].slice(0, limit), modeUsed: "auto", enginesUsed, escalated: true, diagnostics };
   }
   return { items: fast, modeUsed: "auto", enginesUsed, escalated: false, diagnostics };
 }

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -1,32 +1,86 @@
 import { JSDOM } from "jsdom";
 import { Readability } from "@mozilla/readability";
 
+/** Build UA + language headers */
 function uaHeaders() {
-  const ua = process.env.USER_AGENT || "mcp-universal-tools/0.1";
+  const ua = process.env.USER_AGENT || "mcp-web-calc/0.2";
   const lang = process.env.LANG_DEFAULT || "vi";
-  return { "User-Agent": ua, "Accept-Language": lang === "vi" ? "vi-VN,vi;q=0.9,en;q=0.8" : "en-US,en;q=0.9" } as Record<string, string>;
+  const accept = lang === "vi" ? "vi-VN,vi;q=0.9,en;q=0.8" : "en-US,en;q=0.9";
+  return { "User-Agent": ua, "Accept-Language": accept } as Record<string, string>;
 }
 
+function toMs(env: string | undefined, def: number) {
+  const n = Number(env);
+  return Number.isFinite(n) && n > 0 ? n : def;
+}
+
+async function fetchWithTimeout(input: RequestInfo | URL, init: RequestInit = {}, timeoutMs = 15000): Promise<Response> {
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+const HTTP_TIMEOUT = toMs(process.env.HTTP_TIMEOUT, 15000);
+const MAX_BYTES = toMs(process.env.MAX_BYTES, 20 * 1024 * 1024); // allow override via env
+
 export interface ExtractedDoc {
-  title?: string; byline?: string; siteName?: string; lang?: string; text: string; url: string; length?: number;
+  title?: string;
+  byline?: string;
+  siteName?: string;
+  lang?: string;
+  text: string;
+  url: string;
+  length?: number;
+}
+
+function isBlockedHost(hostname: string): boolean {
+  const lower = hostname.toLowerCase();
+  if (lower === "localhost" || lower === "127.0.0.1" || lower === "::1") return true;
+  // also block common local dev TLDs
+  if (lower.endsWith(".local") || lower.endsWith(".localhost")) return true;
+  return false;
 }
 
 export async function fetchAndExtract(url: string): Promise<ExtractedDoc> {
-  const res = await fetch(url, { redirect: "follow", headers: uaHeaders() });
+  const u = new URL(url);
+  if (isBlockedHost(u.hostname)) {
+    throw new Error("Blocked localhost/private URL");
+  }
+
+  const res = await fetchWithTimeout(u.toString(), { redirect: "follow", headers: uaHeaders() }, HTTP_TIMEOUT);
   if (!res.ok) throw new Error(`Fetch ${res.status} for ${url}`);
+
+  const lenHeader = res.headers.get("content-length");
+  const len = Number(lenHeader || "0");
+  if (len > 0 && len > MAX_BYTES) throw new Error(`Content too large: ${len} bytes`);
+
   const ct = res.headers.get("content-type") || "";
-  if (ct.includes("pdf")) {
-    const buf = Buffer.from(await res.arrayBuffer());
+  const buf = Buffer.from(await res.arrayBuffer());
+  if (buf.byteLength > MAX_BYTES) throw new Error(`Content too large (downloaded)`);
+
+  if (ct.includes("application/pdf") || u.pathname.toLowerCase().endsWith(".pdf")) {
     const pdfParse: any = (await import("pdf-parse")).default;
     const data = await pdfParse(buf);
     return { text: data.text || "", url, title: data.info?.Title, length: data.numpages };
   }
-  const html = await res.text();
+
+  const html = buf.toString("utf8");
   const dom = new JSDOM(html, { url });
   const reader = new Readability(dom.window.document);
   const article = reader.parse();
   if (article) {
-    return { title: article.title ?? undefined, byline: article.byline || undefined, siteName: article.siteName || undefined, lang: (dom.window.document.documentElement.lang || undefined) as string | undefined, text: (article.textContent || ""), url, length: (typeof article.length === "number" ? article.length : undefined) };
+    return {
+      title: article.title ?? undefined,
+      byline: (article as any).byline ?? undefined,
+      siteName: (article as any).siteName ?? undefined,
+      text: (article as any).textContent ?? "",
+      url,
+      length: typeof (article as any).length === "number" ? (article as any).length : undefined
+    };
   }
   const text = dom.window.document.body.textContent || "";
   return { text, url, title: dom.window.document.title };

--- a/src/wikipedia.ts
+++ b/src/wikipedia.ts
@@ -8,20 +8,45 @@ export interface WikiSummary {
 }
 
 // Single entry point: get summary for a Wikipedia title
+function uaHeaders(lang = process.env.LANG_DEFAULT || "vi") {
+  const ua = process.env.USER_AGENT || "mcp-web-calc/0.2";
+  const accept = lang === "vi" ? "vi-VN,vi;q=0.9,en;q=0.8" : "en-US,en;q=0.9";
+  return { "User-Agent": ua, "Accept-Language": accept } as Record<string, string>;
+}
+
+function toMs(env: string | undefined, def: number) {
+  const n = Number(env);
+  return Number.isFinite(n) && n > 0 ? n : def;
+}
+
+async function fetchWithTimeout(input: RequestInfo | URL, init: RequestInit = {}, timeoutMs = 15000): Promise<Response> {
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(t);
+  }
+}
+
 export async function wikiGetSummary(title: string, lang: string = "vi"): Promise<WikiSummary> {
   const base = `https://${lang}.wikipedia.org`;
   const sumUrl = new URL(`${base}/api/rest_v1/page/summary/${encodeURIComponent(title)}`);
-  const sres = await fetch(sumUrl);
-  if (!sres.ok) {
+  try {
+    const sres = await fetchWithTimeout(sumUrl, { headers: uaHeaders(lang) }, toMs(process.env.HTTP_TIMEOUT, 15000));
+    if (!sres.ok) {
+      return { lang, title, url: `${base}/wiki/${encodeURIComponent(title)}` };
+    }
+    const s = await sres.json() as any;
+    return {
+      lang,
+      title: s.title ?? title,
+      url: s.content_urls?.desktop?.page ?? `${base}/wiki/${encodeURIComponent(title)}`,
+      description: s.description,
+      extract: s.extract,
+      thumbnailUrl: s.thumbnail?.source
+    };
+  } catch {
     return { lang, title, url: `${base}/wiki/${encodeURIComponent(title)}` };
   }
-  const s = await sres.json() as any;
-  return {
-    lang,
-    title: s.title ?? title,
-    url: s.content_urls?.desktop?.page ?? `${base}/wiki/${encodeURIComponent(title)}`,
-    description: s.description,
-    extract: s.extract,
-    thumbnailUrl: s.thumbnail?.source
-  };
 }


### PR DESCRIPTION
## Summary
- Add global HTTP timeouts (env: HTTP_TIMEOUT, default 15s)
- Close Playwright context/browser in finally to prevent leaks
- Respect limit consistently; default from MAX_RESULTS
- Basic SSRF guard (block localhost/loopback)
- Cap downloaded size (MAX_BYTES, default 20MB)
- Consistent UA/Accept-Language; cleanup .env.example

## Env
USER_AGENT=mcp-web-calc/0.2 (https://local)
HTTP_TIMEOUT=15000
MAX_RESULTS=10
LANG_DEFAULT=vi
MAX_BYTES=20971520
